### PR TITLE
[BE] feat: 가상 런칭 제품 스펙 저장 기능 구현

### DIFF
--- a/backend/src/main/java/codebadger/virtual_launch/common/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/codebadger/virtual_launch/common/config/JpaAuditingConfig.java
@@ -1,0 +1,20 @@
+package codebadger.virtual_launch.common.config;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+public class JpaAuditingConfig {
+
+    @Bean
+    public DateTimeProvider auditingDateTimeProvider() {
+        // 서버 위치와 상관없이 항상 세계 표준시 기준으로 시간 반환
+        return () -> Optional.of(OffsetDateTime.now(ZoneOffset.UTC));
+    }
+}

--- a/backend/src/main/java/codebadger/virtual_launch/common/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/codebadger/virtual_launch/common/domain/BaseTimeEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.OffsetDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -19,7 +20,7 @@ public abstract class BaseTimeEntity {
     @Schema(description = "생성 일시", example = "2024-06-01T12:00:00")
     private OffsetDateTime createdAt;
 
-    @CreatedDate
+    @LastModifiedDate
     @Column(nullable = false)
     @Schema(description = "수정 일시", example = "2024-06-01T12:30:00")
     private OffsetDateTime updatedAt;

--- a/backend/src/main/java/codebadger/virtual_launch/common/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/codebadger/virtual_launch/common/domain/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package codebadger.virtual_launch.common.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class) // 자동 시간 기록 JPA Auditing 활성화
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    @Schema(description = "생성 일시", example = "2024-06-01T12:00:00")
+    private OffsetDateTime createdAt;
+
+    @CreatedDate
+    @Column(nullable = false)
+    @Schema(description = "수정 일시", example = "2024-06-01T12:30:00")
+    private OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/crawling/presentation/ReviewController.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/crawling/presentation/ReviewController.java
@@ -33,9 +33,7 @@ public class ReviewController {
                 .map(ReviewCrawlingResponse.ReviewDetail::from)
                 .collect(Collectors.toList());
 
-        ReviewCrawlingResponse response = new ReviewCrawlingResponse(
-                details
-        );
+        ReviewCrawlingResponse response = new ReviewCrawlingResponse(details);
 
         return SuccessResponse.ok(response, "경쟁사 리뷰 크롤링 및 저장이 완료되었습니다");
     }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/application/CategoryService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/application/CategoryService.java
@@ -7,11 +7,9 @@ import codebadger.virtual_launch.domain.simulation.domain.repository.CategoryRep
 import codebadger.virtual_launch.domain.simulation.domain.entity.RequiredSpec;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CategoryService {

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/application/CategoryService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/application/CategoryService.java
@@ -2,9 +2,9 @@ package codebadger.virtual_launch.domain.simulation.application;
 
 import codebadger.virtual_launch.common.exception.BusinessException;
 import codebadger.virtual_launch.common.exception.ErrorCode;
-import codebadger.virtual_launch.domain.simulation.domain.Category;
-import codebadger.virtual_launch.domain.simulation.domain.CategoryRepository;
-import codebadger.virtual_launch.domain.simulation.domain.RequiredSpec;
+import codebadger.virtual_launch.domain.simulation.domain.entity.Category;
+import codebadger.virtual_launch.domain.simulation.domain.repository.CategoryRepository;
+import codebadger.virtual_launch.domain.simulation.domain.entity.RequiredSpec;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,12 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CategoryService {
 
-    private final CategoryRepository categoryRespoitory;
+    private final CategoryRepository categoryRepository;
 
     // 카테고리명을 통한 조회
     @Transactional(readOnly = true)
     public Map<String, Map<String, RequiredSpec>> getSpecsByCategoryName(String categoryName) {
-        return categoryRespoitory.findByCategoryName(categoryName)
+        return categoryRepository.findByCategoryName(categoryName)
                 .map(Category::getRequiredSpecs)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
     }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/application/ProductSpecService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/application/ProductSpecService.java
@@ -1,0 +1,18 @@
+package codebadger.virtual_launch.domain.simulation.application;
+
+import codebadger.virtual_launch.common.domain.BaseTimeEntity;
+import codebadger.virtual_launch.domain.simulation.domain.repository.CategoryRepository;
+import codebadger.virtual_launch.domain.simulation.domain.repository.ProductSpecRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProductSpecService {
+
+    private final ProductSpecRepository productSpecRepository;
+    private final CategoryRepository categoryRepository;
+
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/application/ProductSpecService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/application/ProductSpecService.java
@@ -1,8 +1,14 @@
 package codebadger.virtual_launch.domain.simulation.application;
 
-import codebadger.virtual_launch.common.domain.BaseTimeEntity;
+import codebadger.virtual_launch.common.exception.BusinessException;
+import codebadger.virtual_launch.common.exception.ErrorCode;
+import codebadger.virtual_launch.domain.simulation.domain.entity.Category;
+import codebadger.virtual_launch.domain.simulation.domain.entity.ProductSpec;
+import codebadger.virtual_launch.domain.simulation.domain.entity.ProductStatus;
 import codebadger.virtual_launch.domain.simulation.domain.repository.CategoryRepository;
 import codebadger.virtual_launch.domain.simulation.domain.repository.ProductSpecRepository;
+import codebadger.virtual_launch.domain.simulation.presentation.dto.ProductSpecResponse;
+import codebadger.virtual_launch.domain.simulation.presentation.dto.ProductSpecSaveRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,4 +21,33 @@ public class ProductSpecService {
     private final ProductSpecRepository productSpecRepository;
     private final CategoryRepository categoryRepository;
 
+    // 가상 런칭 제품 스펙 저장 메서드
+    public ProductSpecResponse saveProductSpec(ProductSpecSaveRequest request) {
+
+        // 카테고리 ID가 없을 경우 기본값 1L로 설정
+        Long categoryId = (request.categoryId() == null || request.categoryId() == 0)
+                ? 1L : request.categoryId();
+
+        // 카테고리 Id 확인
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        // 제품 사양과 카테고리 간의 연관 관계를 설정하는 메서드
+        ProductSpec productSpec = ProductSpec.builder()
+                .category(category)
+                .productName(request.productName())
+                .productDescription(request.productDescription())
+                .productImageUrl(request.productImageUrl())
+                .plannedLaunchDate(request.targetLaunchDate())
+                .plannedPrice(request.plannedPrice())
+                .detailedSpecs(request.detailedSpecs())
+                .productStatus(ProductStatus.PLANNING)
+                .build();
+
+        // 가상 런칭 제품 스펙 저장
+        ProductSpec savedProductSpec = productSpecRepository.save(productSpec);
+
+        // response DTO 반환
+        return ProductSpecResponse.from(savedProductSpec);
+    }
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/Category.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/Category.java
@@ -1,12 +1,16 @@
-package codebadger.virtual_launch.domain.simulation.domain;
+package codebadger.virtual_launch.domain.simulation.domain.entity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -37,4 +41,8 @@ public class Category {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "required_specs", columnDefinition = "jsonb")
     private Map<String, Map<String, RequiredSpec>> requiredSpecs; // 필수 입력 스펙 폼 데이터
+
+    // 하나의 카테고리는 여러 제품 스펙을 가질 수 있다 (1:N)
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    private List<ProductSpec> productSpecs = new ArrayList<>();
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/ProductSpec.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/ProductSpec.java
@@ -1,5 +1,6 @@
 package codebadger.virtual_launch.domain.simulation.domain.entity;
 
+import codebadger.virtual_launch.common.domain.BaseTimeEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -29,7 +30,7 @@ import org.hibernate.type.SqlTypes;
 @Builder
 @Entity
 @Table(name = "product_spec")
-public class ProductSpec { // 가상 런칭 제품 스펙
+public class ProductSpec extends BaseTimeEntity { // 가상 런칭 제품 스펙
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,14 +56,14 @@ public class ProductSpec { // 가상 런칭 제품 스펙
     private String productImageUrl;
 
     @Schema(description = "출시 예정일 (ISO 8601 형식)", example = "2026-10-15T09:00:00+09:00")
-    private OffsetDateTime targetLaunchDate;
+    private OffsetDateTime plannedLaunchDate;
+
+    @Schema(description = "희망 출시 가격")
+    private BigDecimal plannedPrice;
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "required_specs", columnDefinition = "jsonb")
-    private Map<String, Map<String, RequiredSpec>> targetSpecs; // 제품 상세 스펙 (가변 데이터)
-
-    @Schema(description = "희망 출시 가격")
-    private BigDecimal targetLaunchPrice;
+    private Map<String, Map<String, RequiredSpec>> detailedSpecs; // 제품 상세 스펙 (가변 데이터)
 
     @Schema(description = "제품 상태")
     private ProductStatus productStatus;

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/ProductSpec.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/ProductSpec.java
@@ -1,0 +1,69 @@
+package codebadger.virtual_launch.domain.simulation.domain.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "product_spec")
+public class ProductSpec { // 가상 런칭 제품 스펙
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long productId;
+
+    // 외래 키 - 하나의 카테고리는 여러 제품 스펙을 가질 수 있다 (1:N)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    @Schema(description = "선택한 카테고리")
+    private Category category;
+
+    // 외래 키 - 한 명의 회원은 여러 제품 제품 스펙을 가질 수 있다 (1:N)
+
+    @Column(nullable = false, length = 100)
+    @Schema(description = "제품명")
+    private String productName;
+
+    @Column(columnDefinition = "TEXT")
+    @Schema(description = "제품 상세 설명")
+    private String productDescription;
+
+    @Schema(description = "제품 대표 이미지 URL")
+    private String productImageUrl;
+
+    @Schema(description = "출시 예정일 (ISO 8601 형식)", example = "2026-10-15T09:00:00+09:00")
+    private OffsetDateTime targetLaunchDate;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "required_specs", columnDefinition = "jsonb")
+    private Map<String, Map<String, RequiredSpec>> targetSpecs; // 제품 상세 스펙 (가변 데이터)
+
+    @Schema(description = "희망 출시 가격")
+    private BigDecimal targetLaunchPrice;
+
+    @Schema(description = "제품 상태")
+    private ProductStatus productStatus;
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/ProductStatus.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/ProductStatus.java
@@ -1,7 +1,7 @@
 package codebadger.virtual_launch.domain.simulation.domain.entity;
 
 public enum ProductStatus {
-    PLANNING,      // 기획 중 (사양 입력 단계)
+    PLANNING,      // 기획 중 (사양 입력 단계) - 기본값
     ANALYZING,     // AI 분석 중 (시뮬레이션 가동 중)
     TESTING,       // 가상 테스트 중 (시장 반응 수집 중)
     PRE_LAUNCH,    // 출시 예정 (분석 완료 후 대기)

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/ProductStatus.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/ProductStatus.java
@@ -1,0 +1,10 @@
+package codebadger.virtual_launch.domain.simulation.domain.entity;
+
+public enum ProductStatus {
+    PLANNING,      // 기획 중 (사양 입력 단계)
+    ANALYZING,     // AI 분석 중 (시뮬레이션 가동 중)
+    TESTING,       // 가상 테스트 중 (시장 반응 수집 중)
+    PRE_LAUNCH,    // 출시 예정 (분석 완료 후 대기)
+    LAUNCHED,      // 출시 완료 (최종 리포트 생성 및 완료)
+    CANCELED,      // 기획 중단
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/RequiredSpec.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/entity/RequiredSpec.java
@@ -1,4 +1,4 @@
-package codebadger.virtual_launch.domain.simulation.domain;
+package codebadger.virtual_launch.domain.simulation.domain.entity;
 
 import java.util.List;
 

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/repository/CategoryRepository.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/repository/CategoryRepository.java
@@ -1,5 +1,6 @@
-package codebadger.virtual_launch.domain.simulation.domain;
+package codebadger.virtual_launch.domain.simulation.domain.repository;
 
+import codebadger.virtual_launch.domain.simulation.domain.entity.Category;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/repository/ProductSpecRepository.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/domain/repository/ProductSpecRepository.java
@@ -1,0 +1,7 @@
+package codebadger.virtual_launch.domain.simulation.domain.repository;
+
+import codebadger.virtual_launch.domain.simulation.domain.entity.ProductSpec;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductSpecRepository extends JpaRepository<ProductSpec, Long> {
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/CategoryController.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/CategoryController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/categories")
+@RequestMapping("/api/v1/categories")
 @RequiredArgsConstructor
 public class CategoryController {
 

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/CategoryController.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/CategoryController.java
@@ -2,7 +2,7 @@ package codebadger.virtual_launch.domain.simulation.presentation;
 
 import codebadger.virtual_launch.common.api.SuccessResponse;
 import codebadger.virtual_launch.domain.simulation.application.CategoryService;
-import codebadger.virtual_launch.domain.simulation.domain.RequiredSpec;
+import codebadger.virtual_launch.domain.simulation.domain.entity.RequiredSpec;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/ProductSpecController.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/ProductSpecController.java
@@ -1,6 +1,14 @@
 package codebadger.virtual_launch.domain.simulation.presentation;
 
+import codebadger.virtual_launch.common.api.SuccessResponse;
+import codebadger.virtual_launch.domain.simulation.application.ProductSpecService;
+import codebadger.virtual_launch.domain.simulation.presentation.dto.ProductSpecResponse;
+import codebadger.virtual_launch.domain.simulation.presentation.dto.ProductSpecSaveRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/product-specs")
 @RequiredArgsConstructor
 public class ProductSpecController {
+
+    private final ProductSpecService productSpecService;
+
+    @PostMapping
+    @Operation(summary = "가상 런칭 제품 상세 스펙 작성 및 저장", description = "가상 런칭 제품 상세 스펙 작성 및 저장합니다")
+    public SuccessResponse<ProductSpecResponse> saveProductSpec(@Valid @RequestBody ProductSpecSaveRequest request) {
+        ProductSpecResponse response = productSpecService.saveProductSpec(request);
+
+        return SuccessResponse.ok(response, "가상 런칭 제품 상세 스펙 작성 및 저장이 완료되었습니다");
+    }
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/ProductSpecController.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/ProductSpecController.java
@@ -1,0 +1,11 @@
+package codebadger.virtual_launch.domain.simulation.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/product-specs")
+@RequiredArgsConstructor
+public class ProductSpecController {
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/dto/ProductSpecResponse.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/dto/ProductSpecResponse.java
@@ -1,0 +1,36 @@
+package codebadger.virtual_launch.domain.simulation.presentation.dto;
+
+import codebadger.virtual_launch.domain.simulation.domain.entity.ProductSpec;
+import codebadger.virtual_launch.domain.simulation.domain.entity.ProductStatus;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record ProductSpecResponse(
+        Long productId,
+        String categoryName,
+        String productName,
+        String productDescription,
+        String productImageUrl,
+        OffsetDateTime plannedLaunchDate,
+        BigDecimal plannedPrice,
+        ProductStatus productStatus,
+        OffsetDateTime createdAt
+) {
+        public static ProductSpecResponse from(ProductSpec entity) {
+            return new ProductSpecResponse(
+                    entity.getProductId(),
+                    entity.getCategory().getCategoryName(),
+                    entity.getProductName(),
+                    entity.getProductDescription(),
+                    entity.getProductImageUrl(),
+                    entity.getPlannedLaunchDate(),
+                    entity.getPlannedPrice(),
+                    entity.getProductStatus(),
+                    entity.getCreatedAt()
+            );
+        }
+
+        public String getFormattedPrice() {
+            return plannedPrice + "원";
+        }
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/dto/ProductSpecSaveRequest.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/dto/ProductSpecSaveRequest.java
@@ -1,0 +1,18 @@
+package codebadger.virtual_launch.domain.simulation.presentation.dto;
+
+import codebadger.virtual_launch.domain.simulation.domain.entity.RequiredSpec;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+public record ProductSpecSaveRequest(
+        @NotNull Long categoryId,
+        @NotNull String productName,
+        String productDescription,
+        String productImageUrl,
+        OffsetDateTime targetLaunchDate,
+        BigDecimal targetLaunchPrice,
+        Map<String, Map<String, RequiredSpec>> detailedSpecs
+) {
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/dto/ProductSpecSaveRequest.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/simulation/presentation/dto/ProductSpecSaveRequest.java
@@ -1,18 +1,54 @@
 package codebadger.virtual_launch.domain.simulation.presentation.dto;
 
 import codebadger.virtual_launch.domain.simulation.domain.entity.RequiredSpec;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.Map;
 
+@Schema(description = "가상 런칭 제품 스펙 데이터 요청")
 public record ProductSpecSaveRequest(
+        @Schema(description = "카테고리 ID", example = "1")
         @NotNull Long categoryId,
-        @NotNull String productName,
+
+        @Schema(description = "제품명", example = "비전북 Pro 16")
+        @NotBlank String productName,
+
+        @Schema(description = "제품 상세 설명", example = "M3 Max 칩셋이 탑재된 전문가용 고성능 노트북")
         String productDescription,
+
+        @Schema(description = "제품 이미지 URL", example = "https://example.com/images/laptop-pro.png")
         String productImageUrl,
+
+        @Schema(description = "출시 예정일 (ISO 8601)", example = "2026-10-15T09:00:00+09:00")
         OffsetDateTime targetLaunchDate,
-        BigDecimal targetLaunchPrice,
+
+        @Schema(description = "목표 출시가", example = "3500000")
+        BigDecimal plannedPrice,
+
+        @Schema(
+                description = "카테고리별 상세 스펙 데이터 (SQL에 정의된 노트북 스펙 예시)",
+                example = """
+                {
+                  "technical_specs": {
+                    "rated_voltage": { "label": "정격 전압", "type": "string", "unit": "V" },
+                    "power_consumption": { "label": "소비 전력", "type": "number", "unit": "W" },
+                    "weight": { "label": "무게", "type": "number", "unit": "kg" }
+                  },
+                  "product_specs": {
+                    "processor": { "label": "프로세서(CPU)", "type": "select", "options": ["M3 Max"], "unit": "" },
+                    "ram": { "label": "메모리(RAM)", "type": "select", "options": ["32GB"], "unit": "GB" },
+                    "graphics": { "label": "그래픽(GPU)", "type": "select", "options": ["RTX 4070"], "unit": "" }
+                  },
+                  "compliance": {
+                    "kc_auth": { "label": "KC 인증 번호", "type": "string", "unit": "" },
+                    "warranty": { "label": "무상 보증 기간", "type": "select", "options": ["2년"], "unit": "" }
+                  }
+                }
+                """
+        )
         Map<String, Map<String, RequiredSpec>> detailedSpecs
 ) {
 }


### PR DESCRIPTION
**## 😉 연관 이슈
#12 

## 🚀 작업 내용
가상 런칭 제품의 상세 스펙을 기록하고 관리하기 위한 기반 로직을 구현

POST /api/v1/product-specs 엔드포인트 생성
모든 생성/수정 시간을 OffsetDateTime(UTC) 기준으로 기록하도록 설정

<img width="1735" height="852" alt="스크린샷 2026-03-26 오후 9 59 24" src="https://github.com/user-attachments/assets/9a040687-6b01-4aa7-b4f0-f94bf3942b3b" />

