### PR TITLE
[BE] feat: 크레딧 지갑 엔티티 설계 및 기본 차감 로직 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// Spring Retry: 재시도 로직 라이브러리
-	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.retry:spring-retry:2.0.6'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// Spring Retry: 재시도 로직 라이브러리
+	implementation 'org.springframework.retry:spring-retry'
 }
 
 dependencyManagement {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 
 	// Spring Retry: 재시도 로직 라이브러리
 	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 dependencyManagement {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -69,7 +69,6 @@ dependencies {
 
 	// Spring Retry: 재시도 로직 라이브러리
 	implementation 'org.springframework.retry:spring-retry:2.0.6'
-	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 dependencyManagement {

--- a/backend/src/main/java/codebadger/virtual_launch/common/config/RetryConfig.java
+++ b/backend/src/main/java/codebadger/virtual_launch/common/config/RetryConfig.java
@@ -1,10 +1,10 @@
 package codebadger.virtual_launch.common.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.resilience.annotation.Retryable;
+import org.springframework.core.Ordered;
+import org.springframework.retry.annotation.EnableRetry;
 
 @Configuration
-@Retryable
+@EnableRetry(order = Ordered.LOWEST_PRECEDENCE - 1)
 public class RetryConfig {
-
 }

--- a/backend/src/main/java/codebadger/virtual_launch/common/config/RetryConfig.java
+++ b/backend/src/main/java/codebadger/virtual_launch/common/config/RetryConfig.java
@@ -1,0 +1,10 @@
+package codebadger.virtual_launch.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.resilience.annotation.Retryable;
+
+@Configuration
+@Retryable
+public class RetryConfig {
+
+}

--- a/backend/src/main/java/codebadger/virtual_launch/common/exception/ErrorCode.java
+++ b/backend/src/main/java/codebadger/virtual_launch/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     // 지갑
     LACK_OF_BALANCE(HttpStatus.BAD_REQUEST, "W001", "지갑 잔액이 부족합니다."),
     INVALID_CREDIT_VALUE(HttpStatus.BAD_REQUEST, "W002", "유효하지 않은 금액입니다."),
+    CONCURRENCY_ERROR(HttpStatus.CONFLICT,"WOO3", "이미 수정된 데이터입니다. 다시 시도해 주세요." ),
 
     // 리뷰 크롤링
     CRAWLING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CR001", "리뷰 크롤링에 실패했습니다."),

--- a/backend/src/main/java/codebadger/virtual_launch/common/exception/ErrorCode.java
+++ b/backend/src/main/java/codebadger/virtual_launch/common/exception/ErrorCode.java
@@ -15,8 +15,9 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 회원입니다."),
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "M002", "이미 사용 중인 이메일입니다."),
 
-    // 잔액
+    // 지갑
     LACK_OF_BALANCE(HttpStatus.BAD_REQUEST, "W001", "지갑 잔액이 부족합니다."),
+    INVALID_CREDIT_VALUE(HttpStatus.BAD_REQUEST, "W002", "유효하지 않은 금액입니다."),
 
     // 리뷰 크롤링
     CRAWLING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CR001", "리뷰 크롤링에 실패했습니다."),

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
@@ -1,5 +1,9 @@
 package codebadger.virtual_launch.domain.member.application;
 
+import codebadger.virtual_launch.domain.member.domain.entity.CreditOwnerType;
+import codebadger.virtual_launch.domain.member.domain.entity.CreditWallet;
+import codebadger.virtual_launch.domain.member.domain.repository.CreditWalletRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +13,24 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CreditService {
 
+    private final CreditWalletRepository creditWalletRepository;
+
+    public void deductCredit(Long ownerId, CreditOwnerType ownerType, Long amount) {
+        // 1. 도메인 서비스나 레포지토리를 통해 주체에 맞는 지갑 조회
+        CreditWallet wallet = findWalletOrThrow(ownerId, ownerType);
+
+        // 2. 비즈니스 로직 수행 (엔티티 내부 메서드 호출)
+        wallet.deduct(amount);
+    }
+
+    private CreditWallet findWalletOrThrow(Long id, CreditOwnerType type) {
+        return switch (type) {
+            case MEMBER -> creditWalletRepository.findByMemberId(id)
+                    .orElseThrow(() -> new EntityNotFoundException("Member wallet not found: " + id));
+            case COMPANY -> creditWalletRepository.findByCompanyId(id)
+                    .orElseThrow(() -> new EntityNotFoundException("Company wallet not found: " + id));
+        };
+    }
 
 
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
@@ -25,7 +25,7 @@ public class CreditService {
     @Retryable(
             retryFor = {ObjectOptimisticLockingFailureException.class}, // 낙관적 락 예외 시 재시도
             maxAttempts = 3, // 최대 3번 시도 (처음 1번 + 재시도 2번)
-            backoff = @Backoff(delay = 100) // 0.1초 간격으로 재시도
+            backoff = @Backoff(delay = 50, multiplier = 2, random = true) // 0.1초 간격으로 재시도
     )
     @Transactional
     public Long deductCredit(Long ownerId, CreditOwnerType ownerType, Long amount) {

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
@@ -15,12 +15,16 @@ public class CreditService {
 
     private final CreditWalletRepository creditWalletRepository;
 
-    public void deductCredit(Long ownerId, CreditOwnerType ownerType, Long amount) {
+    @Transactional
+    public Long deductCredit(Long ownerId, CreditOwnerType ownerType, Long amount) {
         // 1. 도메인 서비스나 레포지토리를 통해 주체에 맞는 지갑 조회
         CreditWallet wallet = findWalletOrThrow(ownerId, ownerType);
 
         // 2. 비즈니스 로직 수행 (엔티티 내부 메서드 호출)
         wallet.deduct(amount);
+
+        // 3. 변동된 잔액을 반환
+        return wallet.getBalance();
     }
 
     private CreditWallet findWalletOrThrow(Long id, CreditOwnerType type) {

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
@@ -1,30 +1,43 @@
 package codebadger.virtual_launch.domain.member.application;
 
+import codebadger.virtual_launch.common.exception.BusinessException;
+import codebadger.virtual_launch.common.exception.ErrorCode;
 import codebadger.virtual_launch.domain.member.domain.entity.CreditOwnerType;
 import codebadger.virtual_launch.domain.member.domain.entity.CreditWallet;
 import codebadger.virtual_launch.domain.member.domain.repository.CreditWalletRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CreditService {
 
     private final CreditWalletRepository creditWalletRepository;
 
+    @Retryable(
+            retryFor = {ObjectOptimisticLockingFailureException.class}, // 낙관적 락 예외 시 재시도
+            maxAttempts = 3, // 최대 3번 시도 (처음 1번 + 재시도 2번)
+            backoff = @Backoff(delay = 100) // 0.1초 간격으로 재시도
+    )
     @Transactional
     public Long deductCredit(Long ownerId, CreditOwnerType ownerType, Long amount) {
-        // 1. 도메인 서비스나 레포지토리를 통해 주체에 맞는 지갑 조회
         CreditWallet wallet = findWalletOrThrow(ownerId, ownerType);
-
-        // 2. 비즈니스 로직 수행 (엔티티 내부 메서드 호출)
         wallet.deduct(amount);
-
-        // 3. 변동된 잔액을 반환
         return wallet.getBalance();
+    }
+
+    @Recover // 3번 모두 실패했을 때 실행될 복구 로직
+    public Long recover(ObjectOptimisticLockingFailureException e, Long ownerId, CreditOwnerType ownerType, Long amount) {
+        log.error("크레딧 차감 최종 실패 - OwnerID: {}, Error: {}", ownerId, e.getMessage());
+        throw new BusinessException(ErrorCode.CONCURRENCY_ERROR); // 사용자에게 알림
     }
 
     private CreditWallet findWalletOrThrow(Long id, CreditOwnerType type) {

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/application/CreditService.java
@@ -1,0 +1,14 @@
+package codebadger.virtual_launch.domain.member.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CreditService {
+
+
+
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditOwnerType.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditOwnerType.java
@@ -1,0 +1,5 @@
+package codebadger.virtual_launch.domain.member.domain.entity;
+
+public enum CreditOwnerType {
+    MEMBER, COMPANY
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
@@ -44,4 +44,25 @@ public class CreditWallet {
         this.balance = balance;
         this.updatedAt = LocalDateTime.now();
     }
+
+    // 개인용 지갑 생성
+    public static CreditWallet createMemberWallet(Long memberId) {
+        // 1. memberId가 null인지 체크
+        if (memberId == null) {
+            throw new IllegalArgumentException("개인 지갑 생성 시 회원 ID는 필수입니다.");
+        }
+
+        // 2. 내부 생성자를 호출 (개인이므로 companyId는 null, 초기 잔액은 0)
+        return new CreditWallet(memberId, null, 0L);
+    }
+
+    // 기업용 지갑 생성
+    public static CreditWallet createCompanyWallet(Long companyId) {
+        // 1. companyId가 null인지 체크
+        if (companyId == null) {
+            throw new IllegalArgumentException("기업 지갑 생성 시 기업 ID는 필수입니다.");
+        }
+        // 2. 내부 생성자를 호출하여 객체 생성 (이때 memberId는 null로 고정)
+        return new CreditWallet(null, companyId, 0L);
+    }
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
@@ -1,5 +1,7 @@
 package codebadger.virtual_launch.domain.member.domain.entity;
 
+import codebadger.virtual_launch.common.exception.BusinessException;
+import codebadger.virtual_launch.common.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -72,9 +74,9 @@ public class CreditWallet {
         if (amount != null && amount <= balance && amount > 0 )  {
             balance -= amount;
         } else if (amount == null || amount < 0){
-            throw new IllegalArgumentException("유효하지 않은 금액입니다..");
+            throw new BusinessException(ErrorCode.INVALID_CREDIT_VALUE);
         } else if (amount > balance) {
-            throw new IllegalArgumentException("잔액이 부족합니다.");
+            throw new BusinessException(ErrorCode.LACK_OF_BALANCE);
         }
 
     }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
@@ -8,9 +8,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @Table(name = "credit_wallet")
 @Getter

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
@@ -1,0 +1,47 @@
+package codebadger.virtual_launch.domain.member.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "credit_wallet")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreditWallet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "wallet_id")
+    private Long id;
+
+    // Long 타입 잔액
+    @Column(nullable = false)
+    private Long balance;
+
+    // 낙관적 락을 위한 버전 관리
+    @Version
+    private Long version;
+
+    // 식별자(ID) 기반 연관관계
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "company_id")
+    private Long companyId;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private CreditWallet(Long memberId, Long companyId, Long balance) {
+        this.memberId = memberId;
+        this.companyId = companyId;
+        this.balance = balance;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
@@ -43,12 +43,20 @@ public class CreditWallet {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    // CreditWallet.java 내부 수정
+
     @Builder
     private CreditWallet(Long memberId, Long companyId, Long balance) {
         this.memberId = memberId;
         this.companyId = companyId;
-        this.balance = balance;
-        this.updatedAt = LocalDateTime.now();
+        this.balance = (balance != null) ? balance : 0L; // null 방어 로직 추가
+        // this.updatedAt = LocalDateTime.now(); // 제거: @LastModifiedDate가 처리함
+    }
+
+    // 테스트 편의를 위해 잔액을 지정할 수 있는 정적 팩토리 메서드 추가
+    public static CreditWallet createMemberWalletWithBalance(Long memberId, Long balance) {
+        if (memberId == null) throw new IllegalArgumentException("회원 ID는 필수입니다.");
+        return new CreditWallet(memberId, null, balance);
     }
 
     // 개인용 지갑 생성

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
@@ -65,4 +65,17 @@ public class CreditWallet {
         // 2. 내부 생성자를 호출하여 객체 생성 (이때 memberId는 null로 고정)
         return new CreditWallet(null, companyId, 0L);
     }
+
+    // 잔액에서 금액 차감
+    public void deduct(Long amount) {
+
+        if (amount != null && amount <= balance && amount > 0 )  {
+            balance -= amount;
+        } else if (amount == null || amount < 0){
+            throw new IllegalArgumentException("유효하지 않은 금액입니다..");
+        } else if (amount > balance) {
+            throw new IllegalArgumentException("잔액이 부족합니다.");
+        }
+
+    }
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/entity/CreditWallet.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
@@ -36,6 +37,7 @@ public class CreditWallet {
     @Column(name = "company_id")
     private Long companyId;
 
+    @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/repository/CreditWalletRepository.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/domain/repository/CreditWalletRepository.java
@@ -1,0 +1,13 @@
+package codebadger.virtual_launch.domain.member.domain.repository;
+
+import codebadger.virtual_launch.domain.member.domain.entity.CreditWallet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CreditWalletRepository extends JpaRepository<CreditWallet, Long> {
+
+    Optional<CreditWallet> findByMemberId(Long memberId);
+
+    Optional<CreditWallet> findByCompanyId(Long companyId);
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/presentation/CreditBalanceResponse.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/presentation/CreditBalanceResponse.java
@@ -1,0 +1,4 @@
+package codebadger.virtual_launch.domain.member.presentation;
+
+public record CreditBalanceResponse(Long remainingBalance) {
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/presentation/CreditController.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/presentation/CreditController.java
@@ -1,0 +1,37 @@
+package codebadger.virtual_launch.domain.member.presentation;
+
+import codebadger.virtual_launch.common.api.SuccessResponse;
+import codebadger.virtual_launch.domain.member.application.CreditService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/credits")
+@RequiredArgsConstructor
+public class CreditController {
+
+    private final CreditService creditService;
+
+    @PostMapping("/deduct")
+    public ResponseEntity<SuccessResponse<CreditBalanceResponse>> deductCredit(
+            @RequestBody @Valid CreditDeductRequest request
+    ) {
+        // 1. 서비스를 호출하여 차감 로직을 수행하고 남은 잔액을 받습니다.
+        Long remainingBalance = creditService.deductCredit(
+                request.ownerId(),
+                request.ownerType(),
+                request.amount()
+        );
+
+        // 2. 결과 DTO를 생성합니다.
+        CreditBalanceResponse response = new CreditBalanceResponse(remainingBalance);
+
+        // 3. ResponseEntity에 SuccessResponse를 담아 200 OK와 함께 반환합니다.
+        return ResponseEntity.ok(SuccessResponse.ok(response));
+    }
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/member/presentation/CreditDeductRequest.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/member/presentation/CreditDeductRequest.java
@@ -1,0 +1,17 @@
+package codebadger.virtual_launch.domain.member.presentation;
+
+import codebadger.virtual_launch.domain.member.domain.entity.CreditOwnerType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreditDeductRequest(
+        @NotNull(message = "소유자 ID는 필수입니다.")
+        Long ownerId,
+
+        @NotNull(message = "소유자 타입은 필수입니다.")
+        CreditOwnerType ownerType,
+
+        @Positive(message = "차감 금액은 0보다 커야 합니다.")
+        Long amount
+) {
+}

--- a/backend/src/test/java/codebadger/virtual_launch/domain/member/application/CreditServiceConcurrencyTest.java
+++ b/backend/src/test/java/codebadger/virtual_launch/domain/member/application/CreditServiceConcurrencyTest.java
@@ -1,0 +1,67 @@
+package codebadger.virtual_launch.domain.member.application;
+
+import codebadger.virtual_launch.domain.member.domain.entity.CreditOwnerType;
+import codebadger.virtual_launch.domain.member.domain.entity.CreditWallet;
+import codebadger.virtual_launch.domain.member.domain.repository.CreditWalletRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers // 1. JUnit 5가 컨테이너 생명주기를 관리하게 합니다.
+class CreditServiceConcurrencyTest {
+
+    @Container // 2. 컨테이너를 자동으로 시작/종료합니다.
+    @ServiceConnection // 3. 핵심! 위치를 여기 필드 위로 옮겨야 합니다.
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private CreditService creditService;
+
+    @Autowired
+    private CreditWalletRepository creditWalletRepository;
+
+    @Test
+    @DisplayName("동시에 10개의 차감 요청이 들어와도 낙관적 락과 재시도 로직 덕분에 정합성이 유지된다.")
+    void deductCreditConcurrencyTest() throws InterruptedException {
+        // ... (이하 로직은 동일) ...
+        Long ownerId = 1L;
+        CreditWallet walletEntity = CreditWallet.builder()
+                .memberId(ownerId)
+                .balance(500L)
+                .build();
+
+        creditWalletRepository.save(walletEntity);
+
+        int threadCount = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    creditService.deductCredit(ownerId, CreditOwnerType.MEMBER, 100L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        CreditWallet wallet = creditWalletRepository.findByMemberId(ownerId).orElseThrow();
+        assertThat(wallet.getBalance()).isEqualTo(0L);
+    }
+}


### PR DESCRIPTION
## 😉 연관 이슈
#16 
## 🚀 작업 내용
- CreditWallet 엔티티에 @Version 필드를 추가하여 멀티 스레드 환경에서 데이터 수정 충돌을 감지하도록 구현했습니다.
- 동시성 충돌(OptimisticLockingFailureException) 발생 시, 자동으로 재시도하도록 @Retryable 로직을 CreditService에 적용했습니다.
- 모든 스레드가 동시에 재시도하여 다시 충돌하는 '군집 현상'을 막기 위해 backoff 설정에 random = true를 추가했습니다.
- 지수 백오프 적용: 실패 횟수가 늘어날수록 대기 시간을 늘려 시스템 부하를 조절했습니다.
- RetryConfig 설정을 통해 재시도 로직이 @Transactional 외부에서 작동하도록 우선순위를 조정했습니다. 이를 통해 롤백된 트랜잭션이 아닌 새로운 트랜잭션에서 재시도가 수행됨을 보장합니다.
- Testcontainers 기반 동시성 통합 테스트 추가
- ExecutorService와 CountDownLatch를 활용하여 실제 10개의 동시 요청 상황을 시뮬레이션했습니다.
- Testcontainers (PostgreSQL)를 사용하여 실제 운영 환경과 유사한 DB 환경에서 정합성 테스트를 완료했습니다.
## 💬 리뷰 중점사항
