### PR TITLE
[BE] feat: 페르소나 도메인 모델 설계 및 엔티티 구현

### DIFF
--- a/backend/src/main/java/codebadger/virtual_launch/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codebadger/virtual_launch/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import codebadger.virtual_launch.common.api.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -45,6 +46,36 @@ public class GlobalExceptionHandler {
                 errorCode.name(),
                 errorCode.getStatus().value(),
                 "서버 내부에서 알 수 없는 오류가 발생했습니다.",
+                request.getRequestURI(),
+                LocalDateTime.now()
+        );
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    /**
+     * DTO 입력값 검증(@Valid) 실패 시 발생하는 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e, HttpServletRequest request) {
+
+        // 1. 발생한 에러들 중 첫 번째 에러 메시지를 가져옵니다.
+        String firstErrorMessage = e.getBindingResult()
+                .getAllErrors()
+                .getFirst()
+                .getDefaultMessage();
+
+        log.error("[MethodArgumentNotValidException] Message: {}, Path: {}",
+                firstErrorMessage, request.getRequestURI());
+
+        // 2. 미리 정의된 ErrorCode(예: INVALID_INPUT_VALUE)를 사용하거나 새로 정의합니다.
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+
+        ErrorResponse response = new ErrorResponse(
+                errorCode.name(),
+                errorCode.getStatus().value(),
+                firstErrorMessage, // DTO에 적어둔 메시지가 여기에 들어갑니다!
                 request.getRequestURI(),
                 LocalDateTime.now()
         );

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/application/PersonaService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/application/PersonaService.java
@@ -1,0 +1,63 @@
+package codebadger.virtual_launch.domain.persona.application;
+
+import codebadger.virtual_launch.domain.persona.domain.entity.PersonaMaster;
+import codebadger.virtual_launch.domain.persona.domain.repository.PersonaMasterRepository;
+import codebadger.virtual_launch.domain.persona.presentation.PersonaCreateRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PersonaService {
+
+    private final PersonaMasterRepository personaMasterRepository;
+
+    @Transactional
+    public Long createPersona(PersonaCreateRequest dto) {
+        // 1. 프롬프트 조립
+        String finalPrompt = buildSystemPrompt(dto);
+
+        // 2. 엔티티 생성 및 저장
+        PersonaMaster persona = PersonaMaster.create(
+                dto.ageGroup(),
+                dto.gender(),
+                dto.incomeLevel(),
+                dto.purchaseCriteria(),
+                finalPrompt
+        );
+
+        return personaMasterRepository.save(persona).getPersonaId();
+    }
+
+    private String buildSystemPrompt(PersonaCreateRequest dto) {
+        StringBuilder prompt = new StringBuilder();
+
+        // [기본 정체성]
+        prompt.append(String.format("당신은 %s 연령대의 %s이며, 현재 %s(이)라는 직업을 가지고 있습니다. ",
+                dto.ageGroup(), dto.gender(), dto.occupation()));
+
+        prompt.append(String.format("소득 수준은 %s 정도입니다. ", dto.incomeLevel()));
+
+        // [구매 성향]
+        prompt.append(String.format("당신은 제품을 구매할 때 '%s'을(를) 가장 중요하게 생각합니다. ",
+                dto.purchaseCriteria().getTitle()));
+        prompt.append(dto.purchaseCriteria().getDescription()).append(". ");
+
+        // [추가 성향 - 선택적 필드 처리]
+        if (dto.personality() != null && !dto.personality().isBlank()) {
+            prompt.append(String.format("성격은 %s한 편입니다. ", dto.personality()));
+        }
+
+        if (dto.lifestyle() != null && !dto.lifestyle().isBlank()) {
+            prompt.append(String.format("평소 라이프스타일은 %s입니다. ", dto.lifestyle()));
+        }
+
+        // [최종 지시]
+        prompt.append("이러한 배경 정보를 바탕으로, 제품에 대해 당신의 성향이 드러나는 구체적이고 솔직한 리뷰를 작성해 주세요.");
+
+        return prompt.toString();
+    }
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/application/PersonaService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/application/PersonaService.java
@@ -24,6 +24,7 @@ public class PersonaService {
         PersonaMaster persona = PersonaMaster.create(
                 dto.ageGroup(),
                 dto.gender(),
+                dto.occupation(),
                 dto.incomeLevel(),
                 dto.purchaseCriteria(),
                 finalPrompt

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
@@ -1,13 +1,14 @@
 package codebadger.virtual_launch.domain.persona.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Table(name = "persona_master")
-@NoArgsConstructor
-@Getter
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class PersonaMaster {
 
     @Id
@@ -31,4 +32,14 @@ public class PersonaMaster {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String systemPrompt; // 직업, 성격 등이 합쳐진 최종 프롬프트
 
+    public static PersonaMaster create(String ageGroup, String gender, String incomeLevel,
+                                       PurchaseCriteria criteria, String systemPrompt) {
+        return PersonaMaster.builder()
+                .ageGroup(ageGroup)
+                .gender(gender)
+                .incomeLevel(incomeLevel)
+                .purchaseCriteria(criteria)
+                .systemPrompt(systemPrompt)
+                .build();
+    }
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
@@ -3,7 +3,6 @@ package codebadger.virtual_launch.domain.persona.domain.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
 
 @Table(name = "persona_master")
 @NoArgsConstructor

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
@@ -1,0 +1,35 @@
+package codebadger.virtual_launch.domain.persona.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Table(name = "persona_master")
+@NoArgsConstructor
+@Getter
+@Entity
+public class PersonaMaster {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long personaId;
+
+    @Column(nullable = false, length = 20)
+    private String ageGroup; // 연령대 (예: "20대", "30대")
+
+    @Column(length = 10)
+    private String gender; // 성별
+
+    @Column(length = 20)
+    private String incomeLevel; // 소득 수준
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private PurchaseCriteria purchaseCriteria; // 주요 구매 기준
+
+    @Lob // 대용량 텍스트 처리를 위한 설정
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String systemPrompt; // 직업, 성격 등이 합쳐진 최종 프롬프트
+
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
@@ -18,10 +18,13 @@ public class PersonaMaster {
     @Column(nullable = false, length = 20)
     private String ageGroup; // 연령대 (예: "20대", "30대")
 
-    @Column(length = 10)
+    @Column(nullable = false, length = 10)
     private String gender; // 성별
 
-    @Column(length = 20)
+    @Column(nullable = false, length = 50)
+    private String occupation; // 직업
+
+    @Column(nullable = false, length = 20)
     private String incomeLevel; // 소득 수준
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PurchaseCriteria.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PurchaseCriteria.java
@@ -1,10 +1,22 @@
 package codebadger.virtual_launch.domain.persona.domain.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum PurchaseCriteria {
-    PERFORMANCE,// 성능 중심
-    DESIGN_FOCUSED,// 디자인/감성
-    CONVENIENCE, // 편의성/실용
-    BRAND_TRUST, // 신뢰/안정
-    INNOVATION, // 트렌드/혁신
-    COST_EFFECTIVE,  // 가성비
+    COST_EFFECTIVE("가성비", "가격 대비 성능과 혜택을 꼼꼼히 따지며 합리적인 소비를 지향함"),
+    HIGH_END("하이엔드", "최고급 사양과 브랜드가 주는 프리미엄 가치를 가장 중요하게 생각함"),
+    PERFORMANCE("성능 중심", "제품의 기술적 완성도, 스펙, 그리고 내구성을 최우선으로 고려함"),
+    DESIGN_FOCUSED("디자인/감성", "제품의 외관, 색상, 그리고 브랜드가 전달하는 감성적인 면을 선호함"),
+    CONVENIENCE("편의성/실용", "사용법이 직관적이고 일상에서 관리가 간편한 제품을 선호함"),
+    BRAND_TRUST("신뢰/안정", "인지도 높은 브랜드의 명성이나 믿을 수 있는 사후 서비스(AS)를 중시함"),
+    INNOVATION("트렌드/혁신", "최신 기술이 적용된 신제품이나 남들이 사용하지 않는 새로운 기능을 선호함");
+
+    private final String title;       // 한글 명칭
+    private final String description; // 상세 설명
+
+    PurchaseCriteria(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PurchaseCriteria.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PurchaseCriteria.java
@@ -1,0 +1,10 @@
+package codebadger.virtual_launch.domain.persona.domain.entity;
+
+public enum PurchaseCriteria {
+    PERFORMANCE,// 성능 중심
+    DESIGN_FOCUSED,// 디자인/감성
+    CONVENIENCE, // 편의성/실용
+    BRAND_TRUST, // 신뢰/안정
+    INNOVATION, // 트렌드/혁신
+    COST_EFFECTIVE,  // 가성비
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/repository/PersonaMasterRepository.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/repository/PersonaMasterRepository.java
@@ -1,0 +1,19 @@
+package codebadger.virtual_launch.domain.persona.domain.repository;
+
+import codebadger.virtual_launch.domain.persona.domain.entity.PersonaMaster;
+import codebadger.virtual_launch.domain.persona.domain.entity.PurchaseCriteria;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PersonaMasterRepository extends JpaRepository<PersonaMaster, Long> {
+
+    // 1. 연령대와 성별로 페르소나 목록 조회
+    List<PersonaMaster> findByAgeGroupAndGender(String ageGroup, String gender);
+
+    // 2. 특정 구매 성향을 가진 페르소나 목록 조회
+    List<PersonaMaster> findByPurchaseCriteria(PurchaseCriteria purchaseCriteria);
+
+    // 3. 해당 조건의 페르소나가 존재하는지 확인 (중복 방지 등)
+    boolean existsByAgeGroupAndGenderAndOccupation(String ageGroup, String gender, String occupation);
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/PersonaController.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/PersonaController.java
@@ -1,0 +1,23 @@
+package codebadger.virtual_launch.domain.persona.presentation;
+
+import codebadger.virtual_launch.common.api.SuccessResponse;
+import codebadger.virtual_launch.domain.persona.application.PersonaService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/personas")
+public class PersonaController {
+
+    private final PersonaService personaService;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<Long>> createPersona(@Valid @RequestBody PersonaCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.ok(personaService.createPersona(request)));
+    }
+
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/PersonaCreateRequest.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/PersonaCreateRequest.java
@@ -1,0 +1,23 @@
+package codebadger.virtual_launch.domain.persona.presentation;
+
+import codebadger.virtual_launch.domain.persona.domain.entity.PurchaseCriteria;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PersonaCreateRequest(
+        @NotBlank(message = "연령대는 필수 입력 항목입니다.")
+        String ageGroup,
+        @NotBlank(message = "성별은 필수 입력 항목입니다.")
+        String gender,
+        @NotBlank(message = "직업은 필수 입력 항목입니다.")
+        String occupation,
+        @NotBlank(message = "소득수준은 필수 입력 항목입니다.")
+        String incomeLevel,
+        @NotNull(message = "구매기준은 필수 입력 항목입니다.")
+        PurchaseCriteria purchaseCriteria,
+        @Size(max = 200)
+        String personality,
+        @Size(max = 200)
+        String lifestyle) {
+}

--- a/backend/src/test/java/codebadger/virtual_launch/domain/persona/application/PersonaServiceTest.java
+++ b/backend/src/test/java/codebadger/virtual_launch/domain/persona/application/PersonaServiceTest.java
@@ -45,6 +45,7 @@ class PersonaServiceTest {
         PersonaMaster savedPersona = PersonaMaster.create(
                 request.ageGroup(),
                 request.gender(),
+                request.occupation(),
                 request.incomeLevel(),
                 request.purchaseCriteria(),
                 "조립된 시스템 프롬프트"

--- a/backend/src/test/java/codebadger/virtual_launch/domain/persona/application/PersonaServiceTest.java
+++ b/backend/src/test/java/codebadger/virtual_launch/domain/persona/application/PersonaServiceTest.java
@@ -1,0 +1,70 @@
+package codebadger.virtual_launch.domain.persona.application;
+
+import codebadger.virtual_launch.domain.persona.domain.entity.PersonaMaster;
+import codebadger.virtual_launch.domain.persona.domain.entity.PurchaseCriteria;
+import codebadger.virtual_launch.domain.persona.domain.repository.PersonaMasterRepository;
+import codebadger.virtual_launch.domain.persona.presentation.PersonaCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.atLeastOnce;
+
+@ExtendWith(MockitoExtension.class)
+class PersonaServiceTest {
+
+    @Mock
+    private PersonaMasterRepository personaMasterRepository;
+
+    @InjectMocks
+    private PersonaService personaService;
+
+    @Test
+    @DisplayName("사용자 입력 데이터를 바탕으로 페르소나가 성공적으로 생성되고 저장된다.")
+    void shouldPersonaCreateSuccessfully() {
+        // [Given] 테스트 환경 준비
+        PersonaCreateRequest request = new PersonaCreateRequest(
+                "20대",
+                "남성",
+                "소프트웨어 엔지니어",
+                "4,000만원 이상",
+                PurchaseCriteria.COST_EFFECTIVE, // 미리 정의된 Enum 값
+                "분석적이고 신중한 성격",
+                "자기계발을 즐기는 라이프스타일"
+        );
+
+        // 가짜 엔티티 생성 (DB 저장 후 ID가 할당된 상황을 모사)
+        PersonaMaster savedPersona = PersonaMaster.create(
+                request.ageGroup(),
+                request.gender(),
+                request.incomeLevel(),
+                request.purchaseCriteria(),
+                "조립된 시스템 프롬프트"
+        );
+
+        // 엔티티의 ID는 보통 DB에서 생성되므로, Reflection을 이용해 강제로 ID를 주입합니다.
+        Long expectedId = 1L;
+        ReflectionTestUtils.setField(savedPersona, "personaId", expectedId);
+
+        // 레포지토리의 save 메서드가 호출되면 위에서 만든 savedPersona를 반환하도록 설정
+        given(personaMasterRepository.save(any(PersonaMaster.class))).willReturn(savedPersona);
+
+        // [When] 실제 서비스 로직 실행
+        Long resultId = personaService.createPersona(request);
+
+        // [Then] 결과 검증
+        assertThat(resultId).isNotNull();
+        assertThat(resultId).isEqualTo(expectedId);
+
+        // 실제로 save 메서드가 한 번 이상 호출되었는지 확인
+        verify(personaMasterRepository, atLeastOnce()).save(any(PersonaMaster.class));
+    }
+}


### PR DESCRIPTION
## 😉 연관 이슈
#20 
## 🚀 작업 내용
- 가성비, 디자인 등 페르소나의 소비 성향을 나타내는 기준값들을 Enum으로 구조화하여 데이터 정합성을 높임
- 연령대, 성별, 직업, 소득 수준 등 페르소나 생성을 위한 핵심 필드들을 구성
- @Enumerated(EnumType.STRING) 설정을 통해 Enum 값이 DB에 문자열로 저장되도록 하여, 향후 Enum 확장 시에도 데이터가 꼬이지 않도록 조치
- Spring Data JPA를 사용하여 페르소나 데이터의 기본적인 저장 및 조회가 가능하도록 구현
## 💬 리뷰 중점사항
