### PR TITLE
[BE] feat: KOSIS 통계 기반 페르소나 경제적 정체성 자동 생성 및 데이터 안정화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 
     // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// Reactor 테스트를 위한 라이브러리
+	testImplementation 'io.projectreactor:reactor-test'
 }
 
 dependencyManagement {

--- a/backend/src/main/java/codebadger/virtual_launch/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codebadger/virtual_launch/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import codebadger.virtual_launch.common.api.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -82,4 +83,38 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
+
+    /**
+     * JSON 파싱 및 Enum 변환 실패 처리
+     * 클라이언트가 Enum에 없는 값을 보냈을 때 발생합니다.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e, HttpServletRequest request) {
+
+        log.error("[HttpMessageNotReadableException] Message: {}, Path: {}",
+                e.getMessage(), request.getRequestURI());
+
+        String detailMessage = "요청 본문을 읽을 수 없습니다. 형식이 올바른지 확인해주세요.";
+
+        // Enum 변환 실패(InvalidFormatException)인 경우 어떤 필드인지 구체적으로 추출
+        if (e.getCause() instanceof com.fasterxml.jackson.databind.exc.InvalidFormatException prevException) {
+            String fieldName = prevException.getPath().isEmpty() ? "unknown" : prevException.getPath().get(0).getFieldName();
+            detailMessage = String.format("'%s' 필드의 값이 유효하지 않습니다. 허용된 값을 확인해주세요.", fieldName);
+        }
+
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+
+        ErrorResponse response = new ErrorResponse(
+                errorCode.name(),               // title (예: INVALID_INPUT_VALUE)
+                errorCode.getStatus().value(),  // status (예: 400)
+                detailMessage,                  // detail (우리가 가공한 메시지)
+                request.getRequestURI(),        // instance (요청 경로)
+                LocalDateTime.now()             // timestamp
+        );
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/application/PersonaService.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/application/PersonaService.java
@@ -2,11 +2,17 @@ package codebadger.virtual_launch.domain.persona.application;
 
 import codebadger.virtual_launch.domain.persona.domain.entity.PersonaMaster;
 import codebadger.virtual_launch.domain.persona.domain.repository.PersonaMasterRepository;
+import codebadger.virtual_launch.domain.persona.infrastructure.AgeRange;
+import codebadger.virtual_launch.domain.persona.infrastructure.IndustryCode;
+import codebadger.virtual_launch.domain.persona.infrastructure.KosisApiClient;
 import codebadger.virtual_launch.domain.persona.presentation.PersonaCreateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+import java.text.DecimalFormat;
 
 @Slf4j
 @Service
@@ -14,50 +20,77 @@ import org.springframework.transaction.annotation.Transactional;
 public class PersonaService {
 
     private final PersonaMasterRepository personaMasterRepository;
+    private final KosisApiClient kosisApiClient;
 
     @Transactional
-    public Long createPersona(PersonaCreateRequest dto) {
-        // 1. 프롬프트 조립
-        String finalPrompt = buildSystemPrompt(dto);
+    public Mono<Long> createPersona(PersonaCreateRequest dto) {
+        // 1. DTO에서 넘겨받은 Enum을 그대로 사용하여 통계 소득 산출
+        return calculateStatisticIncome(dto.ageRange(), dto.industryCode())
+                .flatMap(calculatedIncome -> {
+                    // 2. 시스템 프롬프트 조립 (Enum의 한글 명칭 사용)
+                    String finalPrompt = buildSystemPrompt(dto, calculatedIncome);
 
-        // 2. 엔티티 생성 및 저장
-        PersonaMaster persona = PersonaMaster.create(
-                dto.ageGroup(),
-                dto.gender(),
-                dto.occupation(),
-                dto.incomeLevel(),
-                dto.purchaseCriteria(),
-                finalPrompt
-        );
+                    // 3. 엔티티 생성 및 저장
+                    // PersonaMaster.create 메서드 파라미터 타입이 Enum으로 변경되었는지 확인 필요합니다.
+                    PersonaMaster persona = PersonaMaster.create(
+                            dto.ageRange(),       // AgeRange Enum
+                            dto.gender(),
+                            dto.industryCode(),   // IndustryCode Enum
+                            String.valueOf(calculatedIncome),
+                            dto.purchaseCriteria(),
+                            finalPrompt
+                    );
 
-        return personaMasterRepository.save(persona).getPersonaId();
+                    PersonaMaster saved = personaMasterRepository.save(persona);
+                    log.info("✅ 페르소나 생성 완료: ID={}, 산출 소득={}원", saved.getPersonaId(), calculatedIncome);
+                    return Mono.just(saved.getPersonaId());
+                });
     }
 
-    private String buildSystemPrompt(PersonaCreateRequest dto) {
+    private Mono<Long> calculateStatisticIncome(AgeRange age, IndustryCode industry) {
+        return Mono.zip(
+                kosisApiClient.getMonthlySalaryByAge(age),
+                kosisApiClient.getMonthlySalaryByIndustry(industry)
+        ).map(tuple -> {
+            long ageSalary = tuple.getT1();
+            long industrySalary = tuple.getT2();
+
+            // 가중치 적용 (나이대 70%, 산업군 30%)
+            double finalSalary = (ageSalary * 0.7) + (industrySalary * 0.3);
+            return Math.round(finalSalary);
+        });
+    }
+
+    private String buildSystemPrompt(PersonaCreateRequest dto, long income) {
         StringBuilder prompt = new StringBuilder();
+        DecimalFormat formatter = new DecimalFormat("###,###");
 
         // [기본 정체성]
-        prompt.append(String.format("당신은 %s 연령대의 %s이며, 현재 %s(이)라는 직업을 가지고 있습니다. ",
-                dto.ageGroup(), dto.gender(), dto.occupation()));
+        // 💡 중요: dto.ageRange().getDescription() 처럼 Enum에 정의된 한글 명칭을 사용하세요.
+        // AgeRange Enum에도 IndustryCode처럼 getDescription() 메서드가 있다고 가정합니다.
+        prompt.append(String.format("당신은 %s 연령대의 %s이며, 현재 %s 분야에서 종사하고 있습니다. ",
+                dto.ageRange().getDescription(),
+                dto.gender(),
+                dto.industryCode().getDescription()));
 
-        prompt.append(String.format("소득 수준은 %s 정도입니다. ", dto.incomeLevel()));
+        prompt.append(String.format("당신의 월평균 소득은 약 %s원입니다. ", formatter.format(income)));
 
         // [구매 성향]
         prompt.append(String.format("당신은 제품을 구매할 때 '%s'을(를) 가장 중요하게 생각합니다. ",
                 dto.purchaseCriteria().getTitle()));
         prompt.append(dto.purchaseCriteria().getDescription()).append(". ");
 
-        // [추가 성향 - 선택적 필드 처리]
+        // [선택적 필드 처리]
         if (dto.personality() != null && !dto.personality().isBlank()) {
             prompt.append(String.format("성격은 %s한 편입니다. ", dto.personality()));
         }
 
+        // 기존 DTO에 있던 lifestyle 필드도 프롬프트에 추가하면 더 풍성해집니다.
         if (dto.lifestyle() != null && !dto.lifestyle().isBlank()) {
-            prompt.append(String.format("평소 라이프스타일은 %s입니다. ", dto.lifestyle()));
+            prompt.append(String.format("라이프스타일은 %s입니다. ", dto.lifestyle()));
         }
 
-        // [최종 지시]
-        prompt.append("이러한 배경 정보를 바탕으로, 제품에 대해 당신의 성향이 드러나는 구체적이고 솔직한 리뷰를 작성해 주세요.");
+        prompt.append("이러한 경제적 배경과 성향을 바탕으로, 제품에 대해 당신의 정체성이 드러나는 구체적인 리뷰를 작성해 주세요.");
 
         return prompt.toString();
     }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
@@ -1,5 +1,7 @@
 package codebadger.virtual_launch.domain.persona.domain.entity;
 
+import codebadger.virtual_launch.domain.persona.infrastructure.AgeRange;
+import codebadger.virtual_launch.domain.persona.infrastructure.IndustryCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,33 +17,41 @@ public class PersonaMaster {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long personaId;
 
-    @Column(nullable = false, length = 20)
-    private String ageGroup; // 연령대 (예: "20대", "30대")
+    // 💡 String -> AgeRange Enum으로 변경
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private AgeRange ageRange;
 
     @Column(nullable = false, length = 10)
     private String gender; // 성별
 
+    // 💡 String occupation -> IndustryCode Enum으로 변경
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
-    private String occupation; // 직업
+    private IndustryCode industryCode;
 
     @Column(nullable = false, length = 20)
-    private String incomeLevel; // 소득 수준
+    private String incomeLevel; // 산출된 소득 수준
 
     @Enumerated(EnumType.STRING)
     @Column(length = 50)
     private PurchaseCriteria purchaseCriteria; // 주요 구매 기준
 
-    @Lob // 대용량 텍스트 처리를 위한 설정
+    @Lob
     @Column(nullable = false, columnDefinition = "TEXT")
-    private String systemPrompt; // 직업, 성격 등이 합쳐진 최종 프롬프트
+    private String systemPrompt; // 최종 조립된 프롬프트
 
-    public static PersonaMaster create(String ageGroup, String gender, String incomeLevel,
-                                       String occupation, PurchaseCriteria criteria, String systemPrompt) {
+    public static PersonaMaster create(AgeRange ageRange,
+                                       String gender,
+                                       IndustryCode industryCode,
+                                       String incomeLevel,
+                                       PurchaseCriteria criteria,
+                                       String systemPrompt) {
         return PersonaMaster.builder()
-                .ageGroup(ageGroup)
+                .ageRange(ageRange)
                 .gender(gender)
+                .industryCode(industryCode)
                 .incomeLevel(incomeLevel)
-                .occupation(occupation)
                 .purchaseCriteria(criteria)
                 .systemPrompt(systemPrompt)
                 .build();

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/domain/entity/PersonaMaster.java
@@ -36,11 +36,12 @@ public class PersonaMaster {
     private String systemPrompt; // 직업, 성격 등이 합쳐진 최종 프롬프트
 
     public static PersonaMaster create(String ageGroup, String gender, String incomeLevel,
-                                       PurchaseCriteria criteria, String systemPrompt) {
+                                       String occupation, PurchaseCriteria criteria, String systemPrompt) {
         return PersonaMaster.builder()
                 .ageGroup(ageGroup)
                 .gender(gender)
                 .incomeLevel(incomeLevel)
+                .occupation(occupation)
                 .purchaseCriteria(criteria)
                 .systemPrompt(systemPrompt)
                 .build();

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/AgeRange.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/AgeRange.java
@@ -1,0 +1,23 @@
+package codebadger.virtual_launch.domain.persona.infrastructure;
+
+import lombok.Getter;
+
+@Getter
+public enum AgeRange {
+
+    // 상수명("한글 명칭", "KOSIS API 코드")
+    ALL("전체", "13102732817AGES.0"),
+    UNDER_29("29세 이하", "13102732817AGES.1"),
+    AGE_30_39("30~39세", "13102732817AGES.2"),
+    AGE_40_49("40~49세", "13102732817AGES.3"),
+    AGE_50_59("50~59세", "13102732817AGES.4"),
+    OVER_60("60세 이상", "13102732817AGES.5");
+
+    private final String description; // 한글 명칭
+    private final String code;        // KOSIS API용 코드
+
+    AgeRange(String description, String code) {
+        this.description = description;
+        this.code = code;
+    }
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/IndustryCode.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/IndustryCode.java
@@ -1,0 +1,32 @@
+package codebadger.virtual_launch.domain.persona.infrastructure;
+
+import lombok.Getter;
+
+@Getter
+public enum IndustryCode {
+
+    // 상수명("한글 명칭", "KOSIS API 코드")
+    ELECTRIC_GAS("전기, 가스, 증기 및 공기 조절 공급업", "190326INDUSTRY_10SDD"),
+    WATER_WASTE("수도, 하수 및 폐기물 처리, 원료 재생업", "190326INDUSTRY_10SEE"),
+    CONSTRUCTION("건설업", "190326INDUSTRY_10SFF"),
+    WHOLESALE_RETAIL("도매 및 소매업", "190326INDUSTRY_10SGG"),
+    TRANSPORT_STORAGE("운수 및 창고업", "190326INDUSTRY_10SHH"),
+    ACCOMMODATION_FOOD("숙박 및 음식점업", "190326INDUSTRY_10SII"),
+    INFO_COMMUNICATION("정보통신업", "190326INDUSTRY_10SJJ"),
+    FINANCE_INSURANCE("금융 및 보험업", "190326INDUSTRY_10SKK"),
+    REAL_ESTATE("부동산업", "190326INDUSTRY_10SLL"),
+    PROFESSIONAL_TECH("전문, 과학 및 기술 서비스업", "190326INDUSTRY_10SMM"),
+    BUSINESS_SUPPORT("사업시설 관리, 사업 지원 및 임대 서비스업", "190326INDUSTRY_10SNN"),
+    EDUCATION("교육 서비스업", "190326INDUSTRY_10SPP"),
+    HEALTH_SOCIAL_WELFARE("보건업 및 사회복지 서비스업", "190326INDUSTRY_10SQQ"),
+    ART_SPORTS_RECREATION("예술, 스포츠 및 여가 관련 서비스업", "190326INDUSTRY_10SRR"),
+    OTHER_SERVICES("협회 및 단체, 수리 및 기타 개인 서비스업", "190326INDUSTRY_10SSS");
+
+    private final String description; // 한글 명칭
+    private final String code;        // KOSIS API용 코드
+
+    IndustryCode(String description, String code) {
+        this.description = description;
+        this.code = code;
+    }
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/IndustryCode.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/IndustryCode.java
@@ -6,21 +6,21 @@ import lombok.Getter;
 public enum IndustryCode {
 
     // 상수명("한글 명칭", "KOSIS API 코드")
-    ELECTRIC_GAS("전기, 가스, 증기 및 공기 조절 공급업", "190326INDUSTRY_10SDD"),
-    WATER_WASTE("수도, 하수 및 폐기물 처리, 원료 재생업", "190326INDUSTRY_10SEE"),
-    CONSTRUCTION("건설업", "190326INDUSTRY_10SFF"),
-    WHOLESALE_RETAIL("도매 및 소매업", "190326INDUSTRY_10SGG"),
-    TRANSPORT_STORAGE("운수 및 창고업", "190326INDUSTRY_10SHH"),
-    ACCOMMODATION_FOOD("숙박 및 음식점업", "190326INDUSTRY_10SII"),
-    INFO_COMMUNICATION("정보통신업", "190326INDUSTRY_10SJJ"),
-    FINANCE_INSURANCE("금융 및 보험업", "190326INDUSTRY_10SKK"),
-    REAL_ESTATE("부동산업", "190326INDUSTRY_10SLL"),
-    PROFESSIONAL_TECH("전문, 과학 및 기술 서비스업", "190326INDUSTRY_10SMM"),
-    BUSINESS_SUPPORT("사업시설 관리, 사업 지원 및 임대 서비스업", "190326INDUSTRY_10SNN"),
+    ELECTRIC_GAS("전기, 가스, 증기 및 공기 조절 공급업", "190326INDUSTRY_10SD"),
+    WATER_WASTE("수도, 하수 및 폐기물 처리, 원료 재생업", "190326INDUSTRY_10SE"),
+    CONSTRUCTION("건설업", "190326INDUSTRY_10SF"),
+    WHOLESALE_RETAIL("도매 및 소매업", "190326INDUSTRY_10SG"),
+    TRANSPORT_STORAGE("운수 및 창고업", "190326INDUSTRY_10SH"),
+    ACCOMMODATION_FOOD("숙박 및 음식점업", "190326INDUSTRY_10SI"),
+    INFO_COMMUNICATION("정보통신업", "190326INDUSTRY_10SJ"),
+    FINANCE_INSURANCE("금융 및 보험업", "190326INDUSTRY_10SK"),
+    REAL_ESTATE("부동산업", "190326INDUSTRY_10SL"),
+    PROFESSIONAL_TECH("전문, 과학 및 기술 서비스업", "190326INDUSTRY_10SM"),
+    BUSINESS_SUPPORT("사업시설 관리, 사업 지원 및 임대 서비스업", "190326INDUSTRY_10SN"),
     EDUCATION("교육 서비스업", "190326INDUSTRY_10SPP"),
-    HEALTH_SOCIAL_WELFARE("보건업 및 사회복지 서비스업", "190326INDUSTRY_10SQQ"),
-    ART_SPORTS_RECREATION("예술, 스포츠 및 여가 관련 서비스업", "190326INDUSTRY_10SRR"),
-    OTHER_SERVICES("협회 및 단체, 수리 및 기타 개인 서비스업", "190326INDUSTRY_10SSS");
+    HEALTH_SOCIAL_WELFARE("보건업 및 사회복지 서비스업", "190326INDUSTRY_10SQ"),
+    ART_SPORTS_RECREATION("예술, 스포츠 및 여가 관련 서비스업", "190326INDUSTRY_10SR"),
+    OTHER_SERVICES("협회 및 단체, 수리 및 기타 개인 서비스업", "190326INDUSTRY_10SS");
 
     private final String description; // 한글 명칭
     private final String code;        // KOSIS API용 코드

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClient.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClient.java
@@ -1,0 +1,24 @@
+package codebadger.virtual_launch.domain.persona.infrastructure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class KosisApiClient {
+
+    private final WebClient webClient;
+    private final String apiKey;
+    private final String baseUrl;
+
+    public KosisApiClient(
+            WebClient.Builder webClientBuilder,
+            @Value("${kosis.api.key}") String apiKey, // properties에서 키 주입 🔑
+            @Value("${kosis.api.url}") String baseUrl  // properties에서 URL 주입 🌐
+    ) {
+        this.webClient = webClientBuilder.baseUrl(baseUrl).build();
+        this.apiKey = apiKey;
+        this.baseUrl = baseUrl;
+    }
+
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClient.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClient.java
@@ -1,24 +1,55 @@
 package codebadger.virtual_launch.domain.persona.infrastructure;
 
+import codebadger.virtual_launch.domain.persona.presentation.KosisIncomeResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Component
 public class KosisApiClient {
 
     private final WebClient webClient;
     private final String apiKey;
-    private final String baseUrl;
 
-    public KosisApiClient(
-            WebClient.Builder webClientBuilder,
-            @Value("${kosis.api.key}") String apiKey, // properties에서 키 주입 🔑
-            @Value("${kosis.api.url}") String baseUrl  // properties에서 URL 주입 🌐
-    ) {
+    // 고용노동부 및 연령별 임금 통계표 관련 상수
+    private static final String ORG_ID = "118";
+    private static final String AGE_SALARY_TBL_ID = "DT_118N_LCE0004";
+    private static final String ITEM_ID_MONTHLY_SALARY = "13103732814DD_5"; // 월급여액
+    private static final String CATEGORY_ALL_WORKERS = "13102732817TYPES.00"; // 전체근로자
+
+    public KosisApiClient(WebClient.Builder webClientBuilder,
+                          @Value("${kosis.api.url}") String baseUrl,
+                          @Value("${kosis.api.key}") String apiKey) {
         this.webClient = webClientBuilder.baseUrl(baseUrl).build();
         this.apiKey = apiKey;
-        this.baseUrl = baseUrl;
     }
 
+    /**
+     * 특정 연령대의 최신 월평균 급여 정보를 가져옵니다.
+     * @param ageRange 연령대 Enum
+     * @return 환산된 급여 금액 (Long)
+     */
+    public Mono<Long> getMonthlySalaryByAge(AgeRange ageRange) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/statisticsData.do")
+                        .queryParam("method", "getList")
+                        .queryParam("apiKey", apiKey)
+                        .queryParam("orgId", ORG_ID)
+                        .queryParam("tblId", AGE_SALARY_TBL_ID)
+                        .queryParam("itmId", ITEM_ID_MONTHLY_SALARY)
+                        .queryParam("objL1", CATEGORY_ALL_WORKERS) // 고용형태: 전체근로자
+                        .queryParam("objL2", ageRange.getCode())   // 연령: 선택한 연령대 코드
+                        .queryParam("format", "json")
+                        .queryParam("jsonVD", "Y")
+                        .queryParam("newEstPrdCnt", "1") // 가장 최신 연도 데이터 1건만 요청
+                        .build())
+                .retrieve()
+                .bodyToFlux(KosisIncomeResponse.class)
+                .next() // Flux의 첫 번째 요소(최신 데이터)를 Mono로 전환
+                .map(KosisIncomeResponse::getConvertedAmount) // "천원" 단위를 "원"으로 환산
+                .defaultIfEmpty(0L) // 데이터가 없을 경우 기본값 0 반환
+                .onErrorReturn(0L); // 에러 발생 시 시스템 중단 방지를 위해 0 반환
+    }
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClient.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClient.java
@@ -1,55 +1,76 @@
 package codebadger.virtual_launch.domain.persona.infrastructure;
 
 import codebadger.virtual_launch.domain.persona.presentation.KosisIncomeResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @Component
 public class KosisApiClient {
 
     private final WebClient webClient;
     private final String apiKey;
+    private final ObjectMapper objectMapper; // JSON 변환 전문가 📦
 
-    // 고용노동부 및 연령별 임금 통계표 관련 상수
-    private static final String ORG_ID = "118";
-    private static final String AGE_SALARY_TBL_ID = "DT_118N_LCE0004";
-    private static final String ITEM_ID_MONTHLY_SALARY = "13103732814DD_5"; // 월급여액
-    private static final String CATEGORY_ALL_WORKERS = "13102732817TYPES.00"; // 전체근로자
-
-    public KosisApiClient(WebClient.Builder webClientBuilder,
+    public KosisApiClient(WebClient webClient,
+                          ObjectMapper objectMapper,
                           @Value("${kosis.api.url}") String baseUrl,
                           @Value("${kosis.api.key}") String apiKey) {
-        this.webClient = webClientBuilder.baseUrl(baseUrl).build();
+
+        // API Key의 '=' 인코딩 방지를 위한 필수 설정
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(baseUrl);
+        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+
+        this.webClient = webClient.mutate()
+                .uriBuilderFactory(factory)
+                .build();
+        this.objectMapper = objectMapper;
         this.apiKey = apiKey;
     }
 
-    /**
-     * 특정 연령대의 최신 월평균 급여 정보를 가져옵니다.
-     * @param ageRange 연령대 Enum
-     * @return 환산된 급여 금액 (Long)
-     */
     public Mono<Long> getMonthlySalaryByAge(AgeRange ageRange) {
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
-                        .path("/statisticsData.do")
                         .queryParam("method", "getList")
                         .queryParam("apiKey", apiKey)
-                        .queryParam("orgId", ORG_ID)
-                        .queryParam("tblId", AGE_SALARY_TBL_ID)
-                        .queryParam("itmId", ITEM_ID_MONTHLY_SALARY)
-                        .queryParam("objL1", CATEGORY_ALL_WORKERS) // 고용형태: 전체근로자
-                        .queryParam("objL2", ageRange.getCode())   // 연령: 선택한 연령대 코드
+                        .queryParam("orgId", "118")
+                        .queryParam("tblId", "DT_118N_LCE0004")
+                        .queryParam("itmId", "13103732814DD_5")
+                        .queryParam("objL1", "13102732817TYPES.00")
+                        .queryParam("objL2", ageRange.getCode())
+                        .queryParam("objL3", "").queryParam("objL4", "")
+                        .queryParam("objL5", "").queryParam("objL6", "")
+                        .queryParam("objL7", "").queryParam("objL8", "")
                         .queryParam("format", "json")
                         .queryParam("jsonVD", "Y")
-                        .queryParam("newEstPrdCnt", "1") // 가장 최신 연도 데이터 1건만 요청
+                        .queryParam("prdSe", "Y")
+                        .queryParam("newEstPrdCnt", "1")
                         .build())
                 .retrieve()
-                .bodyToFlux(KosisIncomeResponse.class)
-                .next() // Flux의 첫 번째 요소(최신 데이터)를 Mono로 전환
-                .map(KosisIncomeResponse::getConvertedAmount) // "천원" 단위를 "원"으로 환산
-                .defaultIfEmpty(0L) // 데이터가 없을 경우 기본값 0 반환
-                .onErrorReturn(0L); // 에러 발생 시 시스템 중단 방지를 위해 0 반환
+                // 1. 명찰(Header)이 무엇이든 상관없이 일단 글자(String)로 다 가져옵니다.
+                .bodyToMono(String.class)
+                .flatMap(json -> {
+                    try {
+                        // 2.ObjectMapper를 사용해 수동으로 List<KosisIncomeResponse>로 변환합니다.
+                        List<KosisIncomeResponse> responses = objectMapper.readValue(json,
+                                new TypeReference<List<KosisIncomeResponse>>() {});
+
+                        return responses.isEmpty() ? Mono.empty() : Mono.just(responses.get(0));
+                    } catch (Exception e) {
+                        // 파싱 실패 시 에러 로그
+                        return Mono.error(new RuntimeException("데이터 변환 실패: " + e.getMessage()));
+                    }
+                })
+                // 3. 변환된 객체에서 금액 추출
+                .map(KosisIncomeResponse::getConvertedAmount)
+                .doOnNext(amount -> System.out.println("💰 최종 환산 금액: " + amount + "원"))
+                .defaultIfEmpty(0L)
+                .onErrorReturn(0L);
     }
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClient.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClient.java
@@ -1,7 +1,6 @@
 package codebadger.virtual_launch.domain.persona.infrastructure;
 
 import codebadger.virtual_launch.domain.persona.presentation.KosisIncomeResponse;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -9,21 +8,18 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import reactor.core.publisher.Mono;
 
-import java.util.List;
-
 @Component
 public class KosisApiClient {
 
     private final WebClient webClient;
     private final String apiKey;
-    private final ObjectMapper objectMapper; // JSON 변환 전문가 📦
+    private final ObjectMapper objectMapper;
 
     public KosisApiClient(WebClient webClient,
                           ObjectMapper objectMapper,
                           @Value("${kosis.api.url}") String baseUrl,
                           @Value("${kosis.api.key}") String apiKey) {
 
-        // API Key의 '=' 인코딩 방지를 위한 필수 설정
         DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(baseUrl);
         factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
 
@@ -34,16 +30,45 @@ public class KosisApiClient {
         this.apiKey = apiKey;
     }
 
+    /**
+     * 산업별 월평균 급여 조회 (DT_118N_LCE305)
+     */
+    public Mono<Long> getMonthlySalaryByIndustry(IndustryCode industryCode) {
+        return fetchSalaryData(
+                "DT_118N_LCE305",
+                "13103732814DD_5",
+                "13102732818TYPES.00",
+                industryCode.getCode()
+        );
+    }
+
+    /**
+     * 나이대별 월평균 급여 조회 (DT_118N_LCE0004)
+     */
     public Mono<Long> getMonthlySalaryByAge(AgeRange ageRange) {
+        return fetchSalaryData(
+                "DT_118N_LCE0004",
+                "13103732814DD_5",
+                "13102732817TYPES.00",
+                ageRange.getCode()
+        );
+    }
+
+    /**
+     * [공통 로직]
+     * 1. 전달받은 파라미터를 그대로 사용
+     * 2. 응답이 배열([])이든 객체({})든 유연하게 처리
+     */
+    private Mono<Long> fetchSalaryData(String tblId, String itmId, String objL1, String categoryCode) {
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .queryParam("method", "getList")
                         .queryParam("apiKey", apiKey)
                         .queryParam("orgId", "118")
-                        .queryParam("tblId", "DT_118N_LCE0004")
-                        .queryParam("itmId", "13103732814DD_5")
-                        .queryParam("objL1", "13102732817TYPES.00")
-                        .queryParam("objL2", ageRange.getCode())
+                        .queryParam("tblId", tblId)
+                        .queryParam("itmId", itmId)
+                        .queryParam("objL1", objL1)
+                        .queryParam("objL2", categoryCode)
                         .queryParam("objL3", "").queryParam("objL4", "")
                         .queryParam("objL5", "").queryParam("objL6", "")
                         .queryParam("objL7", "").queryParam("objL8", "")
@@ -53,23 +78,29 @@ public class KosisApiClient {
                         .queryParam("newEstPrdCnt", "1")
                         .build())
                 .retrieve()
-                // 1. 명찰(Header)이 무엇이든 상관없이 일단 글자(String)로 다 가져옵니다.
                 .bodyToMono(String.class)
                 .flatMap(json -> {
                     try {
-                        // 2.ObjectMapper를 사용해 수동으로 List<KosisIncomeResponse>로 변환합니다.
-                        List<KosisIncomeResponse> responses = objectMapper.readValue(json,
-                                new TypeReference<List<KosisIncomeResponse>>() {});
+                        com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree(json);
 
-                        return responses.isEmpty() ? Mono.empty() : Mono.just(responses.get(0));
+                        // KOSIS 에러 응답 확인
+                        if (node.has("err")) {
+                            System.err.println("❌ KOSIS API 에러 응답 [" + tblId + "]: " + json);
+                            return Mono.empty();
+                        }
+
+                        // 응답 구조 유연화 (배열 vs 객체)
+                        com.fasterxml.jackson.databind.JsonNode targetNode = node.isArray() ? node.get(0) : node;
+                        if (targetNode == null || targetNode.isMissingNode()) return Mono.empty();
+
+                        KosisIncomeResponse response = objectMapper.treeToValue(targetNode, KosisIncomeResponse.class);
+                        return Mono.just(response);
                     } catch (Exception e) {
-                        // 파싱 실패 시 에러 로그
-                        return Mono.error(new RuntimeException("데이터 변환 실패: " + e.getMessage()));
+                        System.err.println("❌ 파싱 실패: " + e.getMessage() + " | 원본: " + json);
+                        return Mono.error(e);
                     }
                 })
-                // 3. 변환된 객체에서 금액 추출
                 .map(KosisIncomeResponse::getConvertedAmount)
-                .doOnNext(amount -> System.out.println("💰 최종 환산 금액: " + amount + "원"))
                 .defaultIfEmpty(0L)
                 .onErrorReturn(0L);
     }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/KosisIncomeResponse.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/KosisIncomeResponse.java
@@ -1,0 +1,45 @@
+package codebadger.virtual_launch.domain.persona.presentation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KosisIncomeResponse {
+
+    @JsonProperty("DT")
+    private String value;          // 통계 수치 (예: "3374")
+
+    @JsonProperty("ITM_NM")
+    private String itemName;       // 항목명 (예: "월급여액")
+
+    @JsonProperty("UNIT_NM")
+    private String unit;           // 단위 (예: "천원")
+
+    @JsonProperty("PRD_DE")
+    private String period;         // 수록 시점 (예: "2024")
+
+    @JsonProperty("NM")
+    private String categoryName;   // 분류 명칭 (예: "정보통신업" 또는 "전체근로자")
+
+    /**
+     * "월급여액" 항목인지 확인하는 유틸리티 메서드
+     */
+    public boolean isSalaryItem() {
+        return "월급여액".equals(itemName);
+    }
+
+    /**
+     * 실제 원화(KRW) 단위로 환산된 금액을 반환
+     */
+    public long getConvertedAmount() {
+        if (value == null || value.isEmpty()) return 0L;
+
+        double rawValue = Double.parseDouble(value);
+        if ("천원".equals(unit)) {
+            return (long) (rawValue * 1000);
+        }
+        return (long) rawValue;
+    }
+}

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/KosisIncomeResponse.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/KosisIncomeResponse.java
@@ -17,9 +17,6 @@ public class KosisIncomeResponse {
     @JsonProperty("UNIT_NM")
     private String unit;           // 단위 (예: "천원")
 
-    @JsonProperty("PRD_DE")
-    private String period;         // 수록 시점 (예: "2024")
-
     @JsonProperty("NM")
     private String categoryName;   // 분류 명칭 (예: "정보통신업" 또는 "전체근로자")
 

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/KosisIncomeResponse.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/KosisIncomeResponse.java
@@ -1,11 +1,13 @@
 package codebadger.virtual_launch.domain.persona.presentation;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KosisIncomeResponse {
 
     @JsonProperty("DT")
@@ -17,8 +19,8 @@ public class KosisIncomeResponse {
     @JsonProperty("UNIT_NM")
     private String unit;           // 단위 (예: "천원")
 
-    @JsonProperty("NM")
-    private String categoryName;   // 분류 명칭 (예: "정보통신업" 또는 "전체근로자")
+    @JsonProperty("C1_NM")
+    private String categoryName;  // 분류 명칭 (예: "정보통신업" 또는 "전체근로자")
 
     /**
      * "월급여액" 항목인지 확인하는 유틸리티 메서드

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/PersonaController.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/PersonaController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,8 +17,11 @@ public class PersonaController {
     private final PersonaService personaService;
 
     @PostMapping
-    public ResponseEntity<SuccessResponse<Long>> createPersona(@Valid @RequestBody PersonaCreateRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.ok(personaService.createPersona(request)));
+    public Mono<ResponseEntity<SuccessResponse<Long>>> createPersona(@Valid @RequestBody PersonaCreateRequest request) {
+        return personaService.createPersona(request)
+                .map(personaId -> ResponseEntity
+                        .status(HttpStatus.CREATED)
+                        .body(SuccessResponse.ok(personaId)));
     }
 
 }

--- a/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/PersonaCreateRequest.java
+++ b/backend/src/main/java/codebadger/virtual_launch/domain/persona/presentation/PersonaCreateRequest.java
@@ -1,23 +1,32 @@
 package codebadger.virtual_launch.domain.persona.presentation;
 
 import codebadger.virtual_launch.domain.persona.domain.entity.PurchaseCriteria;
+import codebadger.virtual_launch.domain.persona.infrastructure.AgeRange;
+import codebadger.virtual_launch.domain.persona.infrastructure.IndustryCode;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record PersonaCreateRequest(
-        @NotBlank(message = "연령대는 필수 입력 항목입니다.")
-        String ageGroup,
+        @NotNull(message = "연령대는 필수 입력 항목입니다.") // Enum은 @NotNull 사용
+        AgeRange ageRange,
+
         @NotBlank(message = "성별은 필수 입력 항목입니다.")
         String gender,
-        @NotBlank(message = "직업은 필수 입력 항목입니다.")
-        String occupation,
+
+        @NotNull(message = "직업(산업군)은 필수 입력 항목입니다.") // Enum은 @NotNull 사용
+        IndustryCode industryCode,
+
         @NotBlank(message = "소득수준은 필수 입력 항목입니다.")
         String incomeLevel,
+
         @NotNull(message = "구매기준은 필수 입력 항목입니다.")
         PurchaseCriteria purchaseCriteria,
+
         @Size(max = 200)
         String personality,
+
         @Size(max = 200)
-        String lifestyle) {
+        String lifestyle
+) {
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -24,4 +24,4 @@ spring.sql.init.data-locations=classpath:sql/category.sql, \
 gemini.api.key=${GEMINI_API_KEY}
 
 kosis.api.key=${KOSIS_API_KEY}
-kosis.api.url=https://kosis.kr/openapi/statisticsData.do
+kosis.api.url=https://kosis.kr/openapi/Param/statisticsParameterData.do

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -22,3 +22,6 @@ spring.sql.init.data-locations=classpath:sql/category.sql, \
   classpath:sql/product_spec.sql
 
 gemini.api.key=${GEMINI_API_KEY}
+
+kosis.api.key=${KOSIS_API_KEY}
+kosis.api.url=https://kosis.kr/openapi/statisticsData.do

--- a/backend/src/test/java/codebadger/virtual_launch/domain/persona/application/PersonaServiceTest.java
+++ b/backend/src/test/java/codebadger/virtual_launch/domain/persona/application/PersonaServiceTest.java
@@ -3,6 +3,9 @@ package codebadger.virtual_launch.domain.persona.application;
 import codebadger.virtual_launch.domain.persona.domain.entity.PersonaMaster;
 import codebadger.virtual_launch.domain.persona.domain.entity.PurchaseCriteria;
 import codebadger.virtual_launch.domain.persona.domain.repository.PersonaMasterRepository;
+import codebadger.virtual_launch.domain.persona.infrastructure.AgeRange;
+import codebadger.virtual_launch.domain.persona.infrastructure.IndustryCode;
+import codebadger.virtual_launch.domain.persona.infrastructure.KosisApiClient;
 import codebadger.virtual_launch.domain.persona.presentation.PersonaCreateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,8 +14,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -24,48 +28,52 @@ class PersonaServiceTest {
     @Mock
     private PersonaMasterRepository personaMasterRepository;
 
+    @Mock
+    private KosisApiClient kosisApiClient; // 새로운 의존성 모킹
+
     @InjectMocks
     private PersonaService personaService;
 
     @Test
-    @DisplayName("사용자 입력 데이터를 바탕으로 페르소나가 성공적으로 생성되고 저장된다.")
+    @DisplayName("KOSIS 데이터를 기반으로 급여를 산출하여 페르소나가 성공적으로 저장된다.")
     void shouldPersonaCreateSuccessfully() {
-        // [Given] 테스트 환경 준비
+        // [Given]
         PersonaCreateRequest request = new PersonaCreateRequest(
-                "20대",
+                AgeRange.UNDER_29,              // Enum 타입 적용
                 "남성",
-                "소프트웨어 엔지니어",
+                IndustryCode.INFO_COMMUNICATION, // Enum 타입 적용
                 "4,000만원 이상",
-                PurchaseCriteria.COST_EFFECTIVE, // 미리 정의된 Enum 값
+                PurchaseCriteria.COST_EFFECTIVE,
                 "분석적이고 신중한 성격",
                 "자기계발을 즐기는 라이프스타일"
         );
 
-        // 가짜 엔티티 생성 (DB 저장 후 ID가 할당된 상황을 모사)
+        // KOSIS API 응답 모킹 (테스트의 일관성을 위해 고정값 반환)
+        given(kosisApiClient.getMonthlySalaryByAge(any())).willReturn(Mono.just(3000000L));
+        given(kosisApiClient.getMonthlySalaryByIndustry(any())).willReturn(Mono.just(5000000L));
+
+        // 가중치 산출 예상 소득: (300만 * 0.7) + (500만 * 0.3) = 360만원
+        String expectedIncome = "3600000";
+
         PersonaMaster savedPersona = PersonaMaster.create(
-                request.ageGroup(),
+                request.ageRange(),
                 request.gender(),
-                request.occupation(),
-                request.incomeLevel(),
+                request.industryCode(),
+                expectedIncome,
                 request.purchaseCriteria(),
                 "조립된 시스템 프롬프트"
         );
 
-        // 엔티티의 ID는 보통 DB에서 생성되므로, Reflection을 이용해 강제로 ID를 주입합니다.
         Long expectedId = 1L;
         ReflectionTestUtils.setField(savedPersona, "personaId", expectedId);
-
-        // 레포지토리의 save 메서드가 호출되면 위에서 만든 savedPersona를 반환하도록 설정
         given(personaMasterRepository.save(any(PersonaMaster.class))).willReturn(savedPersona);
 
-        // [When] 실제 서비스 로직 실행
-        Long resultId = personaService.createPersona(request);
+        // [When & Then] StepVerifier를 사용한 리액티브 스트림 검증
+        StepVerifier.create(personaService.createPersona(request))
+                .expectNext(expectedId) // 예상되는 저장된 ID 확인
+                .verifyComplete();     // 스트림이 정상 종료되는지 확인
 
-        // [Then] 결과 검증
-        assertThat(resultId).isNotNull();
-        assertThat(resultId).isEqualTo(expectedId);
-
-        // 실제로 save 메서드가 한 번 이상 호출되었는지 확인
+        // 레포지토리 저장 호출 여부 검증
         verify(personaMasterRepository, atLeastOnce()).save(any(PersonaMaster.class));
     }
 }

--- a/backend/src/test/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClientTest.java
+++ b/backend/src/test/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClientTest.java
@@ -14,12 +14,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 class KosisApiClientTest {
 
-    // 1. 테스트 환경에서 사용할 ObjectMapper를 직접 정의합니다.
     @TestConfiguration
     static class TestConfig {
         @Bean
         public ObjectMapper objectMapper() {
-            return new ObjectMapper();
+            // 미정의 필드 무시 설정을 빈 레벨에서 해주면 DTO의 @JsonIgnoreProperties가 없어도 안전합니다.
+            return new ObjectMapper()
+                    .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         }
     }
 
@@ -37,9 +38,26 @@ class KosisApiClientTest {
 
         // then
         Long salary = monthlySalaryByAge.block();
+        assertNotNull(salary);
+        assertTrue(salary > 0);
+        System.out.println("✅ [연령별] 최종 결과 금액: " + salary + "원");
+    }
+
+    @Test
+    @DisplayName("정보통신업의 월평균 급여 데이터를 KOSIS에서 정상적으로 가져온다")
+    void testGetMonthlySalaryByIndustry() {
+        // given
+        // 개발자 직군이 포함된 '정보통신업'으로 테스트해봅니다.
+        IndustryCode industryCode = IndustryCode.INFO_COMMUNICATION;
+
+        // when
+        Mono<Long> monthlySalaryByIndustry = kosisApiClient.getMonthlySalaryByIndustry(industryCode);
+
+        // then
+        Long salary = monthlySalaryByIndustry.block();
 
         System.out.println("========================================");
-        System.out.println("✅ 최종 결과 금액: " + salary + "원");
+        System.out.println("✅ [" + industryCode.getDescription() + "] 최종 결과 금액: " + salary + "원");
         System.out.println("========================================");
 
         assertNotNull(salary);

--- a/backend/src/test/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClientTest.java
+++ b/backend/src/test/java/codebadger/virtual_launch/domain/persona/infrastructure/KosisApiClientTest.java
@@ -1,0 +1,48 @@
+package codebadger.virtual_launch.domain.persona.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class KosisApiClientTest {
+
+    // 1. 테스트 환경에서 사용할 ObjectMapper를 직접 정의합니다.
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+    }
+
+    @Autowired
+    private KosisApiClient kosisApiClient;
+
+    @Test
+    @DisplayName("29세 이하의 월평균 급여 데이터를 KOSIS에서 정상적으로 가져온다")
+    void testGetMonthlySalaryByAge() {
+        // given
+        AgeRange ageRange = AgeRange.UNDER_29;
+
+        // when
+        Mono<Long> monthlySalaryByAge = kosisApiClient.getMonthlySalaryByAge(ageRange);
+
+        // then
+        Long salary = monthlySalaryByAge.block();
+
+        System.out.println("========================================");
+        System.out.println("✅ 최종 결과 금액: " + salary + "원");
+        System.out.println("========================================");
+
+        assertNotNull(salary);
+        assertTrue(salary > 0, "조회된 급여가 0보다 커야 합니다.");
+    }
+}


### PR DESCRIPTION
## 😉 연관 이슈
#26 
## 🚀 작업 내용
- KOSIS 외부 API 연동 (KosisApiClient)WebClient를 사용한 비동기 논블로킹 통신 구현.연령별/산업별 월평균 급여 조회 기능 추가 (DT_118N_LCE0004, DT_118N_LCE305).KOSIS API 특유의 파라미터 규격(공백/특수문자 매핑) 이슈 해결 및 응답 구조(Array/Object) 유연화.
- 도메인 로직 및 서비스 고도화 (PersonaService)Mono.zip을 활용하여 두 API를 병렬로 호출함으로써 응답 속도 최적화.가중치 기반 소득 산출 로직 도입 산출된 소득 데이터를 시스템 프롬프트에 자동 주입하여 LLM 페르소나의 정교함 향상.
- 데이터 타입 안정화 (Enum 도입)AgeRange, IndustryCode 등 주요 코드를 Enum으로 전환하여 데이터 정합성 확보.
- DTO(PersonaCreateRequest)부터 Entity(PersonaMaster)까지 일관된 Enum 타입 적용.
- 전역 예외 처리 강화 (GlobalExceptionHandler) Enum 변환 실패(HttpMessageNotReadableException) 시, 어떤 필드에서 에러가 발생했는지 구체적으로 반환하도록 로직 개선.
## 💬 리뷰 중점사항
